### PR TITLE
SNR range

### DIFF
--- a/librarian_ondd/config.ini
+++ b/librarian_ondd/config.ini
@@ -13,3 +13,8 @@ css_bundles =
 # Location of the ONDD socket
 socket = /var/run/ondd.ctrl
 
+# Minimum value for SNR range
+snr_min = 0.2
+
+# Maximum value for SNR range
+snr_max = 0.9

--- a/librarian_ondd/dashboard_plugin.py
+++ b/librarian_ondd/dashboard_plugin.py
@@ -59,7 +59,11 @@ class ONDDDashboardPlugin(DashboardPlugin):
         initial_data = read_ondd_setup()
         preset = match_preset(initial_data)
         ondd_client = request.app.supervisor.exts.ondd
+        snr_min = request.app.config.get('ondd.snr_min', 0.2)
+        snr_max = request.app.config.get('ondd.snr_max', 0.9)
         return dict(status=ondd_client.get_status(),
                     form=ONDDForm(initial_data),
                     files=ondd_client.get_transfers(),
+                    SNR_MIN=snr_min,
+                    SNR_MAX=snr_max,
                     selected_preset=preset)

--- a/librarian_ondd/routes.py
+++ b/librarian_ondd/routes.py
@@ -13,7 +13,10 @@ from .consts import get_form_data_for_preset
 @view('ondd/_status')
 def get_signal_status():
     ondd_client = request.app.supervisor.exts.ondd
-    return dict(status=ondd_client.get_status())
+    snr_min = request.app.config.get('ondd.snr_min', 0.2)
+    snr_max = request.app.config.get('ondd.snr_max', 0.9)
+    return dict(status=ondd_client.get_status(), SNR_MIN=snr_min,
+                SNR_MAX=snr_max)
 
 
 @roca_view('ondd/settings', 'ondd/_settings_form', template_func=template)

--- a/librarian_ondd/views/ondd/_status.tpl
+++ b/librarian_ondd/views/ondd/_status.tpl
@@ -1,11 +1,11 @@
 <%namespace name="ui" file="/ui/widgets.tpl"/>
 
 <%
-    SNR_MAX = 1.6
     BRATE_MAX = 100000.0
     bitrate = th.get_bitrate(status)
     snr = status['snr']
-    snr_pct = round(snr / SNR_MAX * 100)
+    snr_max_delta = SNR_MAX - SNR_MIN
+    snr_pct = round(max(snr - SNR_MIN, 0) / snr_max_delta * 100)
     bitrate_pct = round(bitrate / BRATE_MAX * 100)
 
     has_tuner = th.has_tuner()

--- a/librarian_ondd/views/ondd/_status.tpl
+++ b/librarian_ondd/views/ondd/_status.tpl
@@ -1,7 +1,7 @@
 <%namespace name="ui" file="/ui/widgets.tpl"/>
 
 <%
-    BRATE_MAX = 100000.0
+    BRATE_MAX = 90000.0
     bitrate = th.get_bitrate(status)
     snr = status['snr']
     snr_max_delta = SNR_MAX - SNR_MIN


### PR DESCRIPTION
This feature adds configuration options related to SNR level meter in status partial. It allows the integrator to specify minimum and maximum SNR that should be treated as 0% and 100% respectively in the UI. It also corrects the hard-coded maximum bitrate to be 90 instead of 100 Kbps.
