### PR TITLE
Schedule cache check task after post_start event

### DIFF
--- a/librarian_ondd/hooks.py
+++ b/librarian_ondd/hooks.py
@@ -21,9 +21,11 @@ def initialize(supervisor):
                           method='POST',
                           test=has_invalid_config)
 
+
+def post_start(supervisor):
+    query_cache_storage_status(supervisor)
     refresh_rate = supervisor.config['ondd.cache_refresh_rate']
     supervisor.exts.tasks.schedule(query_cache_storage_status,
                                    args=(supervisor,),
                                    delay=refresh_rate,
                                    periodic=True)
-


### PR DESCRIPTION
librarian-diskspace already works this way, and this particular issue was observable on rpi with a very slow sd card, where databases were not ready for a very long time.
